### PR TITLE
update auth0-php to v8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,13 @@
         }
     ],
     "require": {
-        "auth0/auth0-php": "^7.0",
+        "auth0/auth0-php": "^8.7",
         "ray/aura-web-module": "^0.1.0",
-        "koriym/http-constants": "^1.1",
+        "koriym/http-constants": "^1.2",
         "josegonzalez/dotenv": "^3.2",
-        "ray/di": "^2.15"
+        "ray/di": "^2.15",
+        "nyholm/psr7": "^1.8",
+        "guzzlehttp/guzzle": "^7.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -55,5 +57,10 @@
             "vendor/bin/php-cs-fixer fix -v",
             "vendor/bin/phpcbf src tests"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/src/Provider/AuthenticationClientProvider.php
+++ b/src/Provider/AuthenticationClientProvider.php
@@ -26,6 +26,6 @@ class AuthenticationClientProvider implements ProviderInterface
 
     public function get() : Authentication
     {
-        return new Authentication($this->config['domain'], $this->config['client_id'], $this->config['client_secret']);
+        return new Authentication($this->config);
     }
 }

--- a/tests/Auth0ModuleTest.php
+++ b/tests/Auth0ModuleTest.php
@@ -29,9 +29,10 @@ class Auth0ModuleTest extends TestCase
             {
                 $this->bind(Management::class)->toProvider(FakeManagementClientProvider::class);
                 $this->install(new Auth0Module([
-                    'domain' => 'AUTH0_DOMAIN',
-                    'client_id' => 'AUTH0_CLIENT_ID',
-                    'client_secret' => 'AUTH0_CLIENT_SECRET',
+                    'domain' => 'https://example.com',
+                    'clientId' => 'AUTH0_CLIENT_ID',
+                    'clientSecret' => 'AUTH0_CLIENT_SECRET',
+                    'cookieSecret' => 'AUTH0_COOKIE_SECRET'
                 ]));
             }
         };

--- a/tests/Fake/Provider/FakeManagementClientProvider.php
+++ b/tests/Fake/Provider/FakeManagementClientProvider.php
@@ -28,14 +28,6 @@ class FakeManagementClientProvider implements ProviderInterface
 
     public function get() : Management
     {
-//        $response = $this->authClient->client_credentials([
-//            'audience' => 'https://' . $this->config['domain'] . '/api/v2/',
-//        ]);
-
-        $response = [
-            'access_token' => 'access_token',
-            'domain' => 'domain'
-        ];
-        return new Management($response['access_token'], $this->config['domain']);
+        return new Management($this->config);
     }
 }


### PR DESCRIPTION
## 対応内容

- auth0-phpをv8にアップデート
- guzzleが別途必要になったためインストール
- テストを修正

※PHP8.1以降だとphpcs関連が実行できなかったため別途対応が必要になりそうです